### PR TITLE
Feat/common name

### DIFF
--- a/lib/countriex/country.ex
+++ b/lib/countriex/country.ex
@@ -1,4 +1,6 @@
 defmodule Countriex.Country do
+  @default_locale "en"
+
   @type vat_rate :: nil | integer() | list(integer())
 
   @type optional_string :: String.t() | nil
@@ -9,6 +11,7 @@ defmodule Countriex.Country do
           alpha2: binary(),
           alpha3: binary(),
           alt_currency: optional_string,
+          common_name: map() | nil,
           continent: String.t(),
           country_code: String.t(),
           currency_code: String.t(),
@@ -51,6 +54,7 @@ defmodule Countriex.Country do
     :address_format,
     :alpha2,
     :alpha3,
+    :common_name,
     :continent,
     :country_code,
     :currency_code,
@@ -82,4 +86,34 @@ defmodule Countriex.Country do
     :eu_member,
     :world_region
   ]
+
+  @doc """
+  Returns true if the country has a common name for the locale
+  """
+  @spec common_name?(__MODULE__.t(), locale :: atom() | String.t()) :: boolean()
+
+  def common_name?(country, locale \\ @default_locale)
+
+  def common_name?(%__MODULE__{common_name: nil}, _), do: false
+
+  def common_name?(%__MODULE__{common_name: cn}, locale) when is_atom(locale),
+    do: Map.has_key?(cn, locale)
+
+  def common_name?(m, locale) when is_binary(locale),
+    do: common_name?(m, String.to_atom(locale))
+
+  @doc """
+  Returns the country's common name for the locale or nil
+  """
+  @spec common_name(__MODULE__.t(), locale :: atom() | String.t()) :: String.t() | nil
+
+  def common_name(country, locale \\ @default_locale)
+
+  def common_name(%__MODULE__{common_name: nil}, _), do: nil
+
+  def common_name(%__MODULE__{common_name: cn}, locale) when is_atom(locale),
+    do: Map.get(cn, locale)
+
+  def common_name(m, locale) when is_binary(locale),
+    do: common_name(m, String.to_atom(locale))
 end

--- a/mix.exs
+++ b/mix.exs
@@ -50,8 +50,9 @@ defmodule Countriex.Mixfile do
       {:earmark, "~> 1.0", only: :dev},
       {:ex_doc, "~> 0.14", only: :dev},
       {:httpoison, "~> 1.8", only: :dev},
+      {:memoize, "~> 1.4", only: :dev},
       {:poison, "~> 3.0", only: :dev},
-      {:yaml_elixir, "~> 1.1", only: :dev},
+      {:yaml_elixir, "~> 2.9.0", only: :dev},
       {:morphix, "~> 0.8.0"},
       {:ex_unit_notifier, "~> 0.1", only: :test}
     ]

--- a/mix.exs
+++ b/mix.exs
@@ -3,21 +3,22 @@ defmodule Countriex.Mixfile do
 
   def project do
     [
+      aliases: aliases(),
       app: :countriex,
-      version: "1.0.2",
-      name: "Countriex",
+      build_embedded: Mix.env() == :prod,
+      deps: deps(),
       description:
         "All sorts of useful information about every country. A pure elixir port of the ruby Countries gem",
-      elixir: "~> 1.3",
-      source_url: "https://github.com/navinpeiris/countriex",
-      homepage_url: "https://github.com/navinpeiris/countriex",
-      package: package(),
-      elixirc_paths: elixirc_paths(Mix.env()),
-      build_embedded: Mix.env() == :prod,
-      start_permanent: Mix.env() == :prod,
-      deps: deps(),
       docs: [extras: ["README.md"]],
-      aliases: aliases()
+      elixir: "~> 1.3",
+      elixirc_paths: elixirc_paths(Mix.env()),
+      homepage_url: "https://github.com/navinpeiris/countriex",
+      name: "Countriex",
+      package: package(),
+      source_url: "https://github.com/navinpeiris/countriex",
+      start_permanent: Mix.env() == :prod,
+      version: "1.0.2",
+      xref: [exclude: [YamlElixir]]
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -8,6 +8,7 @@
   "idna": {:hex, :idna, "6.1.1", "8a63070e9f7d0c62eb9d9fcb360a7de382448200fbbd1b106cc96d3d8099df8d", [:rebar3], [{:unicode_util_compat, "~>0.7.0", [hex: :unicode_util_compat, repo: "hexpm", optional: false]}], "hexpm", "92376eb7894412ed19ac475e4a86f7b413c1b9fbb5bd16dccd57934157944cea"},
   "makeup": {:hex, :makeup, "0.8.0", "9cf32aea71c7fe0a4b2e9246c2c4978f9070257e5c9ce6d4a28ec450a839b55f", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "5fbc8e549aa9afeea2847c0769e3970537ed302f93a23ac612602e805d9d1e7f"},
   "makeup_elixir": {:hex, :makeup_elixir, "0.13.0", "be7a477997dcac2e48a9d695ec730b2d22418292675c75aa2d34ba0909dcdeda", [:mix], [{:makeup, "~> 0.8", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "adf0218695e22caeda2820eaba703fa46c91820d53813a2223413da3ef4ba515"},
+  "memoize": {:hex, :memoize, "1.4.2", "cc289c7f1b86a37e7278180aa382bdc8935e8280cbf41659482d29d843bcd16d", [:mix], [], "hexpm", "daabbbf763b07bc2a2aedba6c87945cbc3d9100e46cfa651923a81e098adbcfa"},
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], [], "hexpm", "69b09adddc4f74a40716ae54d140f93beb0fb8978d8636eaded0c31b6f099f16"},
   "mimerl": {:hex, :mimerl, "1.2.0", "67e2d3f571088d5cfd3e550c383094b47159f3eee8ffa08e64106cdf5e981be3", [:rebar3], [], "hexpm", "f278585650aa581986264638ebf698f8bb19df297f66ad91b18910dfc6e19323"},
   "morphix": {:hex, :morphix, "0.8.1", "5342f2baf8b3385e63a1d4ef7586f1d6f89b66e3ae9615fe3b1a85e5e3ff0ddb", [:mix], [], "hexpm", "e2cfd750dcc25c48b1dd97304fcb167f4ccaefc133fa2b9b4cb8619678fac1e3"},
@@ -16,6 +17,6 @@
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm", "fec8660eb7733ee4117b85f55799fd3833eb769a6df71ccf8903e8dc5447cfce"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.6", "cf344f5692c82d2cd7554f5ec8fd961548d4fd09e7d22f5b62482e5aeaebd4b0", [:make, :mix, :rebar3], [], "hexpm", "bdb0d2471f453c88ff3908e7686f86f9be327d065cc1ec16fa4540197ea04680"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.7.0", "bc84380c9ab48177092f43ac89e4dfa2c6d62b40b8bd132b1059ecc7232f9a78", [:rebar3], [], "hexpm", "25eee6d67df61960cf6a794239566599b09e17e668d3700247bc498638152521"},
-  "yamerl": {:hex, :yamerl, "0.7.0", "e51dba652dce74c20a88294130b48051ebbbb0be7d76f22de064f0f3ccf0aaf5", [:rebar3], [], "hexpm", "cb5a4481e2e2ad36db83bd9962153e1a9208e2b2484185e33fc2caac6a50b108"},
-  "yaml_elixir": {:hex, :yaml_elixir, "1.4.0", "8c859bce9677793eb38efeac74edd0eddd892bc741c88b1e46bd22cdb1eb76fd", [:mix], [{:yamerl, "~> 0.5", [hex: :yamerl, repo: "hexpm", optional: false]}], "hexpm", "57f4a0125692fbae645b0241dd28172ac305488e5a7608e0f00a16507ec6fd73"},
+  "yamerl": {:hex, :yamerl, "0.10.0", "4ff81fee2f1f6a46f1700c0d880b24d193ddb74bd14ef42cb0bcf46e81ef2f8e", [:rebar3], [], "hexpm", "346adb2963f1051dc837a2364e4acf6eb7d80097c0f53cbdc3046ec8ec4b4e6e"},
+  "yaml_elixir": {:hex, :yaml_elixir, "2.9.0", "9a256da867b37b8d2c1ffd5d9de373a4fda77a32a45b452f1708508ba7bbcb53", [:mix], [{:yamerl, "~> 0.10", [hex: :yamerl, repo: "hexpm", optional: false]}], "hexpm", "0cb0e7d4c56f5e99a6253ed1a670ed0e39c13fc45a6da054033928607ac08dfc"},
 }


### PR DESCRIPTION
So far we've been relying on the `unofficial_names` field for a semi-reliable source for colloquial country names (or at least something shorter than some official names), but we really should be using proper translations. This patch adds the English language common names for countries, as available, which will do us for now.